### PR TITLE
Notice CQL, which should be SQL-ish enough.

### DIFF
--- a/lib/newrelic-cql/instrumentation.rb
+++ b/lib/newrelic-cql/instrumentation.rb
@@ -14,8 +14,20 @@ DependencyDetection.defer do
 
   executes do
     require 'new_relic/agent/datastores'
+    require 'new_relic/agent/datastores/metric_helper'
 
-    [::Cql::Client::AsynchronousClient, ::Cql::Client::SynchronousClient].each do |klass|
+    ::Cql::Client::AsynchronousClient.class_eval do
+      alias_method :execute_without_newrelic, :execute
+      def execute(cql, *args)
+        metric = NewRelic::Agent::Datastores::MetricHelper.metrics_for('Cql', 'execute')
+        start = Time.now
+        result = execute_without_newrelic(cql, *args)
+        NewRelic::Agent::Datastores.notice_sql(cql, metric, Time.now - start)
+        result
+      end
+    end
+
+    [::Cql::Client::SynchronousClient, ::Cql::Client::AsynchronousClient].each do |klass|
       NewRelic::Agent::Datastores.trace klass, :prepare, 'Cql'
       NewRelic::Agent::Datastores.trace klass, :execute, 'Cql'
       NewRelic::Agent::Datastores.trace klass, :batch, 'Cql'


### PR DESCRIPTION
The idea is to leave all the tracing in place on the various methods,
but add notice_sql by wrapping the async client's execute (which really
underpins almost all operations).
